### PR TITLE
add option to hide commands without notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ set -g @cmdpalette-key-root 'prefix BSpace'
 set -g @cmdpalette-key-copy-mode-vi 'copy-mode-vi C-/'
 ```
 
+### Noted-Only Mode
+
+By default, the keybinding palette shows all key bindings, including raw unannotated ones. To only show bindings that have a human-readable note (registered with `bind-key -N`), set:
+
+```tmux
+set -g @cmdpalette-noted-only on
+```
+
+This filters out noisy raw bindings from plugins and tmux internals, keeping the palette clean and readable.
+
 ### Custom Command List
 
 Command list is a shell script that is sourced by the palette entry file, where we register a series of tmux commands.

--- a/scripts/show-prompt.sh
+++ b/scripts/show-prompt.sh
@@ -23,14 +23,17 @@ source_file() {
 
 list_keys() {
     local table="$1"
+    local noted_only="$(tmux show-options -gqv @cmdpalette-noted-only)"
     if [ -n "${table}" ]; then
         # list key bindings with notes
         tmux list-keys -NT "${table}" |
             sed -E 's/^(\S+)\s+/\1\t/'
         # list key bindings as valid config
-        tmux list-keys -T "${table}" |
-            sh "${SEDKEYBIND}" |
-            sed -E 's/^(\S+)\s+(\S+)\s+(.*)$/\2\t\3/'
+        if [ "${noted_only}" != "on" ]; then
+            tmux list-keys -T "${table}" |
+                sh "${SEDKEYBIND}" |
+                sed -E 's/^(\S+)\s+(\S+)\s+(.*)$/\2\t\3/'
+        fi
     fi
 }
 


### PR DESCRIPTION
If plugins register commands without a note, they won't be searchable, so some power users may want to turn this off, but the average user probably doesn't want to see the raw, un-noted bindings in search results.